### PR TITLE
When etcd dies, dacd dies

### DIFF
--- a/internal/pkg/etcdregistry/keystore.go
+++ b/internal/pkg/etcdregistry/keystore.go
@@ -340,8 +340,7 @@ func (client *etcKeystore) KeepAliveKey(key string) error {
 		for {
 			ka := <-ch
 			if ka == nil {
-				log.Println("Refresh stoped for key: ", key)
-				// TODO: optionally make this log a fatal error?
+				log.Panicf("Unable to refresh key: %s", key)
 				break
 			} else {
 				if counter >= 9 {


### PR DESCRIPTION
Let docker or systemd restore the connection to etcd. Probably should do
a better job of restoring the system when we come back up.