### PR TITLE
dacctl setup optionally accept nodehostnamefile

### DIFF
--- a/cmd/dacctl/main.go
+++ b/cmd/dacctl/main.go
@@ -79,9 +79,14 @@ func runCli(args []string) error {
 			Action: jobProcess,
 		},
 		{
-			Name:   "setup",
-			Usage:  "Create transient buffer, called after waiting for enough free capacity.",
-			Flags:  []cli.Flag{token, job, caller, user, groupid, capacity},
+			Name:  "setup",
+			Usage: "Create transient buffer, called after waiting for enough free capacity.",
+			Flags: []cli.Flag{token, job, caller, user, groupid, capacity,
+				cli.StringFlag{
+					Name:  "nodehostnamefile",
+					Usage: "Path to file containing list of scheduled compute nodes.",
+				},
+			},
 			Action: setup,
 		},
 		{
@@ -113,7 +118,7 @@ func runCli(args []string) error {
 			Flags: []cli.Flag{token, job,
 				cli.StringFlag{
 					Name:  "nodehostnamefile",
-					Usage: "Path to file containing list of compute nodes.",
+					Usage: "Path to file containing list of compute nodes for job.",
 				},
 				// TODO: required when SetExecHost flag set, but currently we just ignore this param!
 				cli.StringFlag{

--- a/cmd/dacctl/main_test.go
+++ b/cmd/dacctl/main_test.go
@@ -83,7 +83,7 @@ func TestCreatePerJobBuffer(t *testing.T) {
 	}()
 
 	setupArgs := strings.Split(
-		"--function setup --token a --job b --caller c --user 1 --groupid 1 --capacity dw:1GiB", " ")
+		"--function setup --token a --job b --caller c --user 1 --groupid 1 --capacity dw:1GiB --nodehostnamefile asdf", " ")
 	err := runCli(setupArgs)
 	assert.Equal(t, "CreatePerJobBuffer", err.Error())
 

--- a/internal/pkg/dacctl/actions/actions.go
+++ b/internal/pkg/dacctl/actions/actions.go
@@ -84,7 +84,7 @@ func (fwa *dacctlActions) CreatePerJobBuffer(c CliContext) error {
 	checkRequiredStrings(c, "token", "job", "caller", "capacity")
 	return dacctl.CreatePerJobBuffer(fwa.volumeRegistry, fwa.poolRegistry, fwa.disk,
 		c.String("token"), c.Int("user"), c.Int("group"), c.String("capacity"),
-		c.String("caller"), c.String("job"))
+		c.String("caller"), c.String("job"), c.String("nodehostnamefile"))
 }
 
 func (fwa *dacctlActions) ShowInstances() error {

--- a/internal/pkg/dacctl/buffer.go
+++ b/internal/pkg/dacctl/buffer.go
@@ -38,10 +38,15 @@ func DeleteBufferComponents(volumeRegistry registry.VolumeRegistry, poolRegistry
 }
 
 func CreatePerJobBuffer(volumeRegistry registry.VolumeRegistry, poolRegistry registry.PoolRegistry, disk fileio.Disk,
-	token string, user int, group int, capacity string, caller string, jobFile string) error {
+	token string, user int, group int, capacity string, caller string, jobFile string, nodeFile string) error {
 	summary, err := ParseJobFile(disk, jobFile)
 	if err != nil {
 		return err
+	}
+
+	if nodeFile != "" {
+		// TODO we could add this into the volume as a scheduling hint, when its available?
+		log.Printf("Ignoring nodeFile in setup: %s", nodeFile)
 	}
 
 	pool, bricksRequired, err := getPoolAndBrickCount(poolRegistry, capacity)

--- a/internal/pkg/dacctl/buffer_test.go
+++ b/internal/pkg/dacctl/buffer_test.go
@@ -16,7 +16,7 @@ func TestCreatePerJobBuffer(t *testing.T) {
 	mockDisk.EXPECT().Lines("jobfile")
 
 	err := CreatePerJobBuffer(mockVolReg, mockPoolReg, mockDisk, "token",
-		2, 2, "", "test", "jobfile")
+		2, 2, "", "test", "jobfile", "nodefile")
 	assert.Equal(t, "must format capacity correctly and include pool", err.Error())
 }
 


### PR DESCRIPTION
This appears to be used when a job is known to be scheduled to a given
node before the buffer is created, that hint is passed down.

Right now we just ignore the hint.