### PR TITLE
Flock

### DIFF
--- a/internal/pkg/pfsprovider/ansible/mount.go
+++ b/internal/pkg/pfsprovider/ansible/mount.go
@@ -241,7 +241,7 @@ func mountLustre(hostname string, lnetSuffix string, mgtHost string, fsname stri
 	// First check if we are mounted already
 	if err := runner.Execute(hostname, fmt.Sprintf("grep %s /etc/mtab", directory)); err != nil {
 		if err := runner.Execute(hostname, fmt.Sprintf(
-			"mount -t lustre %s%s:/%s %s",
+			"mount -t lustre -o flock,nodev,nosuid %s%s:/%s %s",
 			mgtHost, lnetSuffix, fsname, directory)); err != nil {
 			return err
 		}

--- a/internal/pkg/pfsprovider/ansible/mount_test.go
+++ b/internal/pkg/pfsprovider/ansible/mount_test.go
@@ -50,7 +50,7 @@ func Test_mountLustre(t *testing.T) {
 	assert.Equal(t, "host", fake.hostnames[0])
 	assert.Equal(t, "host", fake.hostnames[1])
 	assert.Equal(t, "grep /dac/job1_job /etc/mtab", fake.cmdStrs[0])
-	assert.Equal(t, "mount -t lustre mgt-opa@o2ib1:/fs /dac/job1_job", fake.cmdStrs[1])
+	assert.Equal(t, "mount -t lustre -o flock,nodev,nosuid mgt-opa@o2ib1:/fs /dac/job1_job", fake.cmdStrs[1])
 
 	fake = &fakeRunner{err: errors.New("expected")}
 	runner = fake
@@ -58,7 +58,7 @@ func Test_mountLustre(t *testing.T) {
 	assert.Equal(t, "expected", err.Error())
 	assert.Equal(t, 2, fake.calls)
 	assert.Equal(t, "grep asdf /etc/mtab", fake.cmdStrs[0])
-	assert.Equal(t, "mount -t lustre mgt:/fs asdf", fake.cmdStrs[1])
+	assert.Equal(t, "mount -t lustre -o flock,nodev,nosuid mgt:/fs asdf", fake.cmdStrs[1])
 }
 
 func Test_createSwap(t *testing.T) {

--- a/internal/pkg/pfsprovider/ansible/mount_test.go
+++ b/internal/pkg/pfsprovider/ansible/mount_test.go
@@ -131,7 +131,7 @@ func Test_Mount(t *testing.T) {
 	assert.Equal(t, "client1", fake.hostnames[0])
 	assert.Equal(t, "mkdir -p /dac/job1_job", fake.cmdStrs[0])
 	assert.Equal(t, "grep /dac/job1_job /etc/mtab", fake.cmdStrs[1])
-	assert.Equal(t, "mount -t lustre host1:/ /dac/job1_job", fake.cmdStrs[2])
+	assert.Equal(t, "mount -t lustre -o flock,nodev,nosuid host1:/ /dac/job1_job", fake.cmdStrs[2])
 
 	assert.Equal(t, "mkdir -p /dac/job1_job/swap", fake.cmdStrs[3])
 	assert.Equal(t, "chown 0:0 /dac/job1_job/swap", fake.cmdStrs[4])


### PR DESCRIPTION
add flock as default for mount point. this is required for application thats require posix lock support. eg. Arepo