### PR TITLE
format on teardown

### DIFF
--- a/internal/pkg/pfsprovider/ansible/ansible.go
+++ b/internal/pkg/pfsprovider/ansible/ansible.go
@@ -209,12 +209,6 @@ func executeAnsibleTeardown(fsType FSType, volume registry.Volume, brickAllocati
 		return err
 	}
 
-	formatArgs := "dac.yml -i inventory --tag format"
-	err = executeAnsiblePlaybook(dir, formatArgs)
-	if err != nil {
-		return err
-	}
-
 	// only delete if everything worked, to aid debugging
 	os.RemoveAll(dir)
 	return nil


### PR DESCRIPTION
remove format on teardown. new buffers are formatted before building. this format on teardown will cause extra ware on disks.