### PR TITLE
Fix certain loops over dict.keys() for python3

### DIFF
--- a/fs-ansible/roles/lustre/tasks/format.yaml
+++ b/fs-ansible/roles/lustre/tasks/format.yaml
@@ -31,7 +31,7 @@
         vg: "dac-{{ item }}"
         state: absent
         force: yes
-      loop: "{{ mdts.keys() }}"
+      loop: "{{ mdts.keys() | list }}"
 
     - name: Remove VG
       lvg:
@@ -39,14 +39,13 @@
         pvs: "/dev/{{ item }}"
         force: yes
         state: absent
-      loop: "{{ mdts.keys() }}"
+      loop: "{{ mdts.keys() | list }}"
 
     - name: dmsetup remove lvm
       command: "dmsetup remove dac--{{ item }}-mdt"
       register: command_result
       failed_when: "command_result.rc != 0 and ('device' not in command_result.stderr)"
-      loop: "{{ mdts.keys() }}"
-
+      loop: "{{ mdts.keys() | list }}"
 
   when:
     - mdts is defined
@@ -57,7 +56,7 @@
     vg: "dac-{{ item }}"
     pvs: "/dev/{{ item }}"
     state: present
-  loop: "{{ mdts.keys() }}"
+  loop: "{{ mdts.keys() | list }}"
   when:
     - mdts is defined
   tags: [ 'never', 'reformat_mdts', 'format']
@@ -68,7 +67,7 @@
     vg: "dac-{{ item }}"
     size: "{{ mdt_size }}"
     state: present
-  loop: "{{ mdts.keys() }}"
+  loop: "{{ mdts.keys() | list }}"
   when:
     - mdts is defined
   tags: [ 'never', 'reformat_mdts', 'format']
@@ -89,7 +88,7 @@
         vg: "dac-{{ item }}"
         state: absent
         force: yes
-      loop: "{{ osts.keys() }}"
+      loop: "{{ osts.keys() | list }}"
       when:
         - mdts is defined
 
@@ -98,7 +97,7 @@
         vg: "dac-{{ item }}"
         pvs: "/dev/{{ item }}"
         state: absent
-      loop: "{{ osts.keys() }}"
+      loop: "{{ osts.keys() | list }}"
       when:
         - osts is defined
         - mdts is not defined
@@ -107,7 +106,7 @@
       command: "dmsetup remove dac--{{ item }}-ost"
       register: command_result
       failed_when: "command_result.rc != 0 and ('device' not in command_result.stderr)"
-      loop: "{{ mdts.keys() }}"
+      loop: "{{ mdts.keys() | list }}"
   tags: [ 'never', 'reformat_osts', 'format']
 
 - name: Add VG
@@ -115,7 +114,7 @@
     vg: "dac-{{ item }}"
     pvs: "/dev/{{ item }}"
     state: present
-  loop: "{{ osts.keys() }}"
+  loop: "{{ osts.keys() | list }}"
   when:
     - osts is defined
   tags: [ 'never', 'reformat_osts', 'format']
@@ -126,7 +125,7 @@
     vg: "dac-{{ item }}"
     size: +100%FREE
     state: present
-  loop: "{{ osts.keys() }}"
+  loop: "{{ osts.keys() | list }}"
   when:
     - osts is defined
   tags: [ 'never', 'reformat_osts', 'format']

--- a/fs-ansible/roles/lustre/tasks/mount.yaml
+++ b/fs-ansible/roles/lustre/tasks/mount.yaml
@@ -40,14 +40,14 @@
         path: /lustre/{{ fs_name }}/MDT/{{ item }}
         state: directory
         recurse: yes
-      with_items: "{{ mdts.keys() }}"
+      with_items: "{{ mdts.keys() | list }}"
 
     - name: mount MDTs
       command: mount -t lustre /dev/mapper/dac--{{ item }}-mdt /lustre/{{ fs_name }}/MDT/{{ item }}
       register: command_result
       failed_when: "command_result.rc != 0 and ('is already mounted' not in command_result.stderr)"
       changed_when: "command_result.rc == 0"
-      with_items: "{{ mdts.keys() }}"
+      with_items: "{{ mdts.keys() | list }}"
   when:
     - mdts is defined
   tags: [ 'never', 'start_mdts', 'create_mdt']
@@ -72,14 +72,14 @@
         path: /lustre/{{ fs_name }}/OST/{{ item }}
         state: directory
         recurse: yes
-      with_items: "{{ osts.keys() }}"
+      with_items: "{{ osts.keys() | list }}"
 
     - name: mount OSTs
       command: mount -t lustre /dev/mapper/dac--{{ item }}-ost /lustre/{{ fs_name }}/OST/{{ item }}
       register: command_result
       failed_when: "command_result.rc != 0 and ('is already mounted' not in command_result.stderr)"
       changed_when: "command_result.rc == 0"
-      with_items: "{{ osts.keys() }}"
+      with_items: "{{ osts.keys() | list }}"
 
   when:
     - osts is defined
@@ -123,7 +123,7 @@
       register: command_result
       failed_when: "command_result.rc != 0 and ('not mounted' not in command_result.stderr) and ('mountpoint not found' not in command_result.stderr)"
       changed_when: "command_result.rc == 0"
-      with_items: "{{ mdts.keys() }}"
+      with_items: "{{ mdts.keys() | list }}"
 
     - name: remove mdt mount dir
       file:
@@ -141,7 +141,7 @@
       register: command_result
       failed_when: "command_result.rc != 0 and ('not mounted' not in command_result.stderr) and ('mountpoint not found' not in command_result.stderr)"
       changed_when: "command_result.rc == 0"
-      with_items: "{{ osts.keys() }}"
+      with_items: "{{ osts.keys() | list }}"
 
     - name: Remove OST mount dir
       file:


### PR DESCRIPTION
I was using fs-ansible today with ansible 2.7 installed in a python3
virtualenv (python 3.6) and I stumbled into an error on these loops over
mdt.keys():

'warning: /lustre/fs1/MDT/dict_keys([nvme0n1]): cannot resolve: No such
file or directory'

According to
https://docs.ansible.com/ansible/latest/user_guide/playbooks_python_version.html
python3 dict.keys() method returns a different dictionary_view object
instead of a list, which is what ansible requires here, and thus these
statements should be updated to work with both python versions.

This commit makes this change.