### PR TITLE
Use rm -df instead of -rf

### DIFF
--- a/dac-ansible/master.yml
+++ b/dac-ansible/master.yml
@@ -240,7 +240,7 @@
     - name: Ensure passwordless sudo for dac user
       lineinfile:
         path: /etc/sudoers.d/80-dac
-        line: "dac ALL=(ALL) NOPASSWD: /usr/bin/mkdir -p /dac/*, /usr/bin/chmod 770 /dac/*, /usr/bin/chmod 0600 /dac/*, /usr/bin/chown * /dac/*, /usr/bin/mount -t lustre * /dac/*, /usr/bin/umount /dac/*, /usr/sbin/losetup /dev/loop* /dac/*, /usr/sbin/losetup -d /dev/loop*, /usr/sbin/mkswap /dev/loop*, /usr/sbin/swapon /dev/loop*, /usr/sbin/swapoff /dev/loop*, /usr/bin/ln -s /dac/* /dac/*, /usr/bin/dd if=/dev/zero of=/dac/*, /usr/bin/rm -rf /dac/*, /bin/grep /dac/* /etc/mtab"
+        line: "dac ALL=(ALL) NOPASSWD: /usr/bin/mkdir -p /dac/*, /usr/bin/chmod 770 /dac/*, /usr/bin/chmod 0600 /dac/*, /usr/bin/chown * /dac/*, /usr/bin/mount -t lustre * /dac/*, /usr/bin/umount /dac/*, /usr/sbin/losetup /dev/loop* /dac/*, /usr/sbin/losetup -d /dev/loop*, /usr/sbin/mkswap /dev/loop*, /usr/sbin/swapon /dev/loop*, /usr/sbin/swapoff /dev/loop*, /usr/bin/ln -s /dac/* /dac/*, /usr/bin/dd if=/dev/zero of=/dac/*, /usr/bin/rm -df /dac/*, /bin/grep /dac/* /etc/mtab"
         regexp: "^dac.*$"
         create: yes
         state: present

--- a/docs/install.md
+++ b/docs/install.md
@@ -165,5 +165,5 @@ all the nodes running `dacd`.
 On the compute nodes, it seems possible to restrict sudo access to the
 following:
 ```
-dacd ALL=(ALL) NOPASSWD: /usr/bin/mkdir -p /dac/*, /usr/bin/chmod 770 /dac/*, /usr/bin/chmod 0600 /dac/*, /usr/bin/chown * /dac/*, /usr/bin/mount -t lustre * /dac/*, /usr/bin/umount -l /dac/*, /usr/bin/umount /dac/*, /usr/sbin/losetup /dev/loop* /dac/*, /usr/sbin/losetup -d /dev/loop*, /usr/sbin/mkswap /dev/loop*, /usr/sbin/swapon /dev/loop*, /usr/sbin/swapoff /dev/loop*, /usr/bin/ln -s /dac/* /dac/*, /usr/bin/dd if=/dev/zero of=/dac/*, /usr/bin/rm -rf /dac/*, /bin/grep /dac/* /etc/mtab
+dacd ALL=(ALL) NOPASSWD: /usr/bin/mkdir -p /dac/*, /usr/bin/chmod 770 /dac/*, /usr/bin/chmod 0600 /dac/*, /usr/bin/chown * /dac/*, /usr/bin/mount -t lustre * /dac/*, /usr/bin/umount -l /dac/*, /usr/bin/umount /dac/*, /usr/sbin/losetup /dev/loop* /dac/*, /usr/sbin/losetup -d /dev/loop*, /usr/sbin/mkswap /dev/loop*, /usr/sbin/swapon /dev/loop*, /usr/sbin/swapoff /dev/loop*, /usr/bin/ln -s /dac/* /dac/*, /usr/bin/dd if=/dev/zero of=/dac/*, /usr/bin/rm -df /dac/*, /bin/grep /dac/* /etc/mtab
 ```

--- a/internal/pkg/filesystem_impl/mount.go
+++ b/internal/pkg/filesystem_impl/mount.go
@@ -191,7 +191,7 @@ func umountLustre(hostname string, directory string) error {
 }
 
 func removeSubtree(hostname string, directory string) error {
-	return runner.Execute(hostname, fmt.Sprintf("rm -rf %s", directory))
+	return runner.Execute(hostname, fmt.Sprintf("rm -df %s", directory))
 }
 
 func createSymbolicLink(hostname string, src string, dest string) error {

--- a/internal/pkg/filesystem_impl/mount_test.go
+++ b/internal/pkg/filesystem_impl/mount_test.go
@@ -162,13 +162,13 @@ func Test_Umount(t *testing.T) {
 	assert.Equal(t, 8, fake.calls)
 
 	assert.Equal(t, "client1", fake.hostnames[0])
-	assert.Equal(t, "rm -rf /dac/job4_job_private", fake.cmdStrs[0])
+	assert.Equal(t, "rm -df /dac/job4_job_private", fake.cmdStrs[0])
 	assert.Equal(t, "grep /dac/job4_job /etc/mtab", fake.cmdStrs[1])
 	assert.Equal(t, "umount /dac/job4_job", fake.cmdStrs[2])
-	assert.Equal(t, "rm -rf /dac/job4_job", fake.cmdStrs[3])
+	assert.Equal(t, "rm -df /dac/job4_job", fake.cmdStrs[3])
 
 	assert.Equal(t, "client2", fake.hostnames[7])
-	assert.Equal(t, "rm -rf /dac/job4_job", fake.cmdStrs[7])
+	assert.Equal(t, "rm -df /dac/job4_job", fake.cmdStrs[7])
 }
 
 func Test_Umount_multi(t *testing.T) {
@@ -195,7 +195,7 @@ func Test_Umount_multi(t *testing.T) {
 	assert.Equal(t, "client1", fake.hostnames[0])
 	assert.Equal(t, "grep /dac/job1_persistent_asdf /etc/mtab", fake.cmdStrs[0])
 	assert.Equal(t, "umount /dac/job1_persistent_asdf", fake.cmdStrs[1])
-	assert.Equal(t, "rm -rf /dac/job1_persistent_asdf", fake.cmdStrs[2])
+	assert.Equal(t, "rm -df /dac/job1_persistent_asdf", fake.cmdStrs[2])
 }
 
 func Test_Mount_multi(t *testing.T) {


### PR DESCRIPTION
We shouldn't need to recurse into the directory as it should be empty