### PR TITLE
Increase timeouts for mount and ansible

### DIFF
--- a/internal/pkg/filesystem_impl/ansible.go
+++ b/internal/pkg/filesystem_impl/ansible.go
@@ -240,8 +240,8 @@ func executeAnsiblePlaybook(dir string, args string) error {
 		log.Println("Attempt", i, "of ansible:", cmdStr)
 		cmd := exec.Command("bash", "-c", cmdStr)
 
-		timer := time.AfterFunc(time.Minute*5, func() {
-			log.Println("Time up, waited more than 5 mins to complete.")
+		timer := time.AfterFunc(time.Minute*10, func() {
+			log.Println("Time up, waited more than 10 mins to complete.")
 			if err := cmd.Process.Kill(); err != nil {
 				log.Panicf("error trying to kill process: %s", err.Error())
 			}

--- a/internal/pkg/filesystem_impl/mount.go
+++ b/internal/pkg/filesystem_impl/mount.go
@@ -271,7 +271,7 @@ func (*run) Execute(hostname string, asRoot bool, cmdStr string) error {
 			"-o", "UserKnownHostsFile=/dev/null", hostname, "sudo", cmdStr)
 	}
 
-	timer := time.AfterFunc(time.Minute, func() {
+	timer := time.AfterFunc(time.Minute*5, func() {
 		log.Println("Time up, waited more than 5 mins to complete.")
 		if err := cmd.Process.Kill(); err != nil {
 			log.Panicf("error trying to kill process: %s", err.Error())


### PR DESCRIPTION
The mount timeout was only 1 min, even though the log message said
it was 5 mins. Fixes: #122.

It seems 5 mins isn't long enough for some ansible runs, even when
you increase the ansible forking to equal the number of DAC nodes.
For now try bump this to 10 mins, but leave bug #121 for the config
idea open for now.