### PR TITLE
Ensure MDTs index is sequential.

### DIFF
--- a/internal/pkg/filesystem_impl/ansible_test.go
+++ b/internal/pkg/filesystem_impl/ansible_test.go
@@ -105,6 +105,12 @@ func TestPlugin_GetInventory_MaxMDT(t *testing.T) {
 			Device:        "nvme2n1",
 		})
 	}
+	for i := 1; i <= 4; i = i + 2 {
+		brickAllocations = append(brickAllocations, datamodel.Brick{
+			BrickHostName: datamodel.BrickHostName(fmt.Sprintf("dac%d", i)),
+			Device:        "nvme3n1",
+		})
+	}
 
 	fsUuid := "abcdefgh"
 	result := getInventory(Lustre, fsUuid, brickAllocations)
@@ -115,42 +121,42 @@ func TestPlugin_GetInventory_MaxMDT(t *testing.T) {
         dac1:
           mgs: sdb
           mdts: {nvme1n1: 0}
-          osts: {nvme1n1: 0, nvme2n1: 1}
+          osts: {nvme1n1: 0, nvme2n1: 1, nvme3n1: 26}
         dac3:
-          mdts: {nvme1n1: 2}
-          osts: {nvme1n1: 2, nvme2n1: 3}
+          mdts: {nvme1n1: 1}
+          osts: {nvme1n1: 2, nvme2n1: 3, nvme3n1: 27}
         dac5:
-          mdts: {nvme1n1: 4}
+          mdts: {nvme1n1: 2}
           osts: {nvme1n1: 4, nvme2n1: 5}
         dac7:
-          mdts: {nvme1n1: 6}
+          mdts: {nvme1n1: 3}
           osts: {nvme1n1: 6, nvme2n1: 7}
         dac9:
-          mdts: {nvme1n1: 8}
+          mdts: {nvme1n1: 4}
           osts: {nvme1n1: 8, nvme2n1: 9}
         dac11:
-          mdts: {nvme1n1: 10}
+          mdts: {nvme1n1: 5}
           osts: {nvme1n1: 10, nvme2n1: 11}
         dac13:
-          mdts: {nvme1n1: 12}
+          mdts: {nvme1n1: 6}
           osts: {nvme1n1: 12, nvme2n1: 13}
         dac15:
-          mdts: {nvme1n1: 14}
+          mdts: {nvme1n1: 7}
           osts: {nvme1n1: 14, nvme2n1: 15}
         dac17:
-          mdts: {nvme1n1: 16}
+          mdts: {nvme1n1: 8}
           osts: {nvme1n1: 16, nvme2n1: 17}
         dac19:
-          mdts: {nvme1n1: 18}
+          mdts: {nvme1n1: 9}
           osts: {nvme1n1: 18, nvme2n1: 19}
         dac21:
-          mdts: {nvme1n1: 20}
+          mdts: {nvme1n1: 10}
           osts: {nvme1n1: 20, nvme2n1: 21}
         dac23:
-          mdts: {nvme1n1: 22}
+          mdts: {nvme1n1: 11}
           osts: {nvme1n1: 22, nvme2n1: 23}
         dac25:
-          mdts: {nvme1n1: 24}
+          mdts: {nvme1n1: 12}
           osts: {nvme1n1: 24, nvme2n1: 25}
       vars:
         fs_name: abcdefgh
@@ -159,4 +165,38 @@ func TestPlugin_GetInventory_MaxMDT(t *testing.T) {
         mgsnode: dac1
 `
 	assert.Equal(t, expected, result)
+}
+
+func TestPlugin_GetFSInfo_MaxMDT_lessHosts(t *testing.T) {
+	var brickAllocations []datamodel.Brick
+	for i := 1; i <= 5; i++ {
+		for j := 1; j <= 6; j++ {
+			brickAllocations = append(brickAllocations, datamodel.Brick{
+				BrickHostName: datamodel.BrickHostName(fmt.Sprintf("dac%d", i)),
+				Device:        fmt.Sprintf("nvme%dn1", j),
+			})
+		}
+	}
+	for i := 1; i <= 2; i++ {
+		brickAllocations = append(brickAllocations, datamodel.Brick{
+			BrickHostName: datamodel.BrickHostName(fmt.Sprintf("dac%d", i)),
+			Device:        "nvme11n1",
+		})
+	}
+
+	fsUuid := "abcdefgh"
+	result := getFSInfo(Lustre, fsUuid, brickAllocations)
+	resultStr := fmt.Sprintf("%+v", result.Hosts)
+	expected := `map[` +
+		`dac1:{hostName:dac1 MGS:sdb MDTS:map[nvme1n1:0 nvme2n1:1 nvme3n1:2 nvme4n1:3] ` +
+		`OSTS:map[nvme11n1:30 nvme1n1:0 nvme2n1:1 nvme3n1:2 nvme4n1:3 nvme5n1:4 nvme6n1:5]} ` +
+		`dac2:{hostName:dac2 MGS: MDTS:map[nvme1n1:4 nvme2n1:5 nvme3n1:6 nvme4n1:7] ` +
+		`OSTS:map[nvme11n1:31 nvme1n1:6 nvme2n1:7 nvme3n1:8 nvme4n1:9 nvme5n1:10 nvme6n1:11]} ` +
+		`dac3:{hostName:dac3 MGS: MDTS:map[nvme1n1:8 nvme2n1:9 nvme3n1:10 nvme4n1:11] ` +
+		`OSTS:map[nvme1n1:12 nvme2n1:13 nvme3n1:14 nvme4n1:15 nvme5n1:16 nvme6n1:17]} ` +
+		`dac4:{hostName:dac4 MGS: MDTS:map[nvme1n1:12 nvme2n1:13 nvme3n1:14 nvme4n1:15] ` +
+		`OSTS:map[nvme1n1:18 nvme2n1:19 nvme3n1:20 nvme4n1:21 nvme5n1:22 nvme6n1:23]} ` +
+		`dac5:{hostName:dac5 MGS: MDTS:map[nvme1n1:16 nvme2n1:17 nvme3n1:18 nvme4n1:19] ` +
+		`OSTS:map[nvme1n1:24 nvme2n1:25 nvme3n1:26 nvme4n1:27 nvme5n1:28 nvme6n1:29]}]`
+	assert.Equal(t, expected, resultStr)
 }


### PR DESCRIPTION
Lustre was getting confused about missing MDTs when we had buffer sizes
that mean we started to limit the number of MDTs. You would see
disconnection errors in the logs.

At the same time, do a better job of limiting the max number of MDTs
when you have a large number of NVMe disks spread over a smaller number
of hosts.