### PR TITLE
Fix docker-slurm build

### DIFF
--- a/docker-slurm/Dockerfile
+++ b/docker-slurm/Dockerfile
@@ -8,8 +8,8 @@ LABEL org.label-schema.docker.cmd="docker-compose up -d" \
       org.label-schema.description="Slurm Docker cluster on CentOS 7" \
       maintainer="John Garbutt"
 
-ARG SLURM_TAG=slurm-19-05-2-1
-ARG GOSU_VERSION=1.11
+ARG SLURM_TAG=slurm-19-05-7-1
+ARG GOSU_VERSION=1.12
 
 RUN set -ex \
     && yum makecache fast \

--- a/docker-slurm/docker-compose.yml
+++ b/docker-slurm/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.2"
 
 services:
   mysql:
-    image: mysql:5.7
+    image: mysql:5.7.29
     hostname: mysql
     container_name: mysql
     environment:


### PR DESCRIPTION
Latest MySQL breaks with latest Slurm, so pinned mysql release